### PR TITLE
Refactor to allow specifying arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,43 +1,70 @@
 'use strict';
 
-var _ = require('lodash'),
-    qs = require('qs');
+var qs = require('qs');
 
+var Utils = {
+  buildResponse: function(response_type, response) {
+    if(typeof response === 'string') {
+      return { response_type: response_type, text: response };
+    }
+    else {
+      response.response_type = response_type;
+      return response;
+    }
+  },
+
+  splitCommand: function(command) {
+    var split = command.split(' ');
+    return { commandName: split[0], args: split.slice(1) };
+  }
+};
+
+// wraps logic around routing
 function SlackBot(config) {
   this.config = config;
   this.commands = {};
 }
 
 // add a command
-SlackBot.prototype.addCommand = function(commandName, description, command) {
-  this[commandName] = command;
-  this.commands[commandName] = description;
+SlackBot.prototype.addCommand = function(commandName, desc, command) {
+  var split = Utils.splitCommand(commandName);
+  this[split.commandName] = command;
+  this.commands[split.commandName] = { args: split.args, desc: desc };
 };
 
 // call a stored command
 SlackBot.prototype.callCommand = function(commandName, options, callback) {
-  if(this.commands.hasOwnProperty(commandName))
+  if(this.commands.hasOwnProperty(commandName) && ((options.args || []).length == this.commands[commandName].args.length))
     return this[commandName](options, callback);
+  else
+    return this.help(options, callback);
 };
-
-var buildResponse = function(response_type, response) {
-  if(typeof response === 'string') {
-    return { response_type: response_type, text: response };
-  }
-  else {
-    response.response_type = response_type;
-    return response;
-  }
-}
 
 // respond to the whole channel
 SlackBot.prototype.inChannelResponse = function(response) {
-  return buildResponse('in_channel', response);
+  return Utils.buildResponse('in_channel', response);
 };
 
 // respond to just the requesting user
 SlackBot.prototype.ephemeralResponse = function(response) {
-  return buildResponse('ephemeral', response);
+  return Utils.buildResponse('ephemeral', response);
+};
+
+// respond with a usage message
+SlackBot.prototype.help = function(options, callback) {
+  var command, helpText = '';
+  for(command in this.commands) {
+    helpText += command;
+    if(this.commands[command].args.length)
+      helpText += ' ' + this.commands[command].args.join(' ');
+    helpText += ': ' + this.commands[command].desc + '\n';
+  }
+  helpText += 'help: display this help message';
+
+  callback(null, this.ephemeralResponse({
+    text: 'Available commands:',
+    attachments: [{ text: helpText }]
+  }));
 };
 
 // control the flow of queries from slack
@@ -49,20 +76,11 @@ SlackBot.prototype.buildRouter = function() {
     if (!body.token || body.token != token)
       return context.done(this.ephemeralResponse('Invalid Slack token'));
 
-    var splitCommand = body.text.split(' '),
-      commandName = _.head(splitCommand),
-      commandArgs = _.tail(splitCommand);
-
-    if(commandName === 'help' || !this.commands.hasOwnProperty(commandName)) {
-      var command, helpText = '';
-      for(command in this.commands)
-        helpText += command + ': ' + this.commands[command] + '\n';
-      helpText += 'help: display this help message';
-      return context.done(null, this.ephemeralResponse({ text: 'Available commands:', attachments: [{ text: helpText }] }));
-    }
-    else {
-      return this[commandName]({ userName: body.user_name, args: commandArgs }, context.done);
-    }
+    var split = Utils.splitCommand(body.text);
+    if(split.commandName === 'help' || !this.commands.hasOwnProperty(split.commandName))
+      return this.help({}, context.done);
+    else
+      return this.callCommand(split.commandName, { userName: body.user_name, args: split.args }, context.done);
   }.bind(this);
 };
 

--- a/test.js
+++ b/test.js
@@ -35,7 +35,16 @@ describe('managing commands', function() {
     slackbot.addCommand('test', 'The test command', testCommand);
 
     expect(slackbot.test).to.eq(testCommand);
-    expect(slackbot.commands.test).to.eq('The test command');
+    expect(slackbot.commands.test.desc).to.eq('The test command');
+  });
+
+  it('adds a command with the correct arguments', function() {
+    var slackbot = new SlackBot(),
+      testCommand = function(options, callback) {};
+    slackbot.addCommand('test <arg1> <arg2>', 'The test command', testCommand);
+
+    expect(slackbot.test).to.eq(testCommand);
+    expect(slackbot.commands.test.args).to.deep.eq(['<arg1>', '<arg2>']);
   });
 
   it('calls the correct command with the correct arguments', function() {
@@ -44,7 +53,20 @@ describe('managing commands', function() {
       slackbot = new SlackBot();
     slackbot.addCommand('test', 'test function', spiedFunction);
 
-    var options = {}, callback = {};
+    var options = {}, callback = new Function();
+    slackbot.callCommand('test', options, callback);
+
+    expect(spiedFunction).to.have.been.calledWithExactly(options, callback);
+  });
+
+  it('restricts calling without the correct number of arguments', function() {
+    var sandbox = sinon.sandbox.create(),
+      spiedFunction = sandbox.spy(),
+      slackbot = new SlackBot();
+    slackbot.addCommand('test <arg1>', 'test function', new Function());
+    slackbot.help = spiedFunction;
+
+    var options = {}, callback = new Function();
     slackbot.callCommand('test', options, callback);
 
     expect(spiedFunction).to.have.been.calledWithExactly(options, callback);


### PR DESCRIPTION
Before, you couldn't specify that a slack command required arguments.
With this patch, you can now add commands like:

```
slackBot.addCommand('test <arg1>', function(options, callback) {});
```

which will restrict the calling of that function to the correct number
of arguments.
