### PR TITLE
Allow optional arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,26 +25,40 @@ Commands are added to the slackbot through the `addCommand` function. Sample con
 ```javascript
 var SlackBot = require('lambda-slack-router');
 var slackbot = new SlackBot({ token: "<token>" });
-slackbot.addCommand('ping', 'Ping the lambda', function(options, callback) {
+slackbot.addCommand('ping', 'Ping the lambda', function (options, callback) {
   callback(null, this.inChannelResponse('Hello World'));
 });
 ```
 
 In the above code, a slackbot is created with the given token (used for verifying the authenticity of each request). The ping command is then added to the routing, and when called responds with an in-channel response of 'Hello World'.
 
-The first argument to the `addCommand` function is the name of the command. This can optionally have arguments specified like `ping arg1 arg2`. In that case the router will only invoke that function if the number of arguments matches exactly. Arguments should be space-separated. You can optionally append an ellipsis to the last argument of your command which will allow an unlimited number of arguments to be passed and stored in the `args` object in that parameter as an array. For instance, a command configured like
-
-```javascript
-slackbot.addCommand('echo words...', 'Response with the words given', function(options, callback) {
-  callback(null, this.ephemeralResponse(options.args.words.join(' ')));
-});
-```
-
-would return 'hello world' when called as `/testbot echo hello world`. The second argument is the description of the function. This is used in the generated `help` command, and is useful to your users when they can't remember the syntax of your bot.
+The first argument to the `addCommand` function is the name of the command. The second argument is the description of the function. This is used in the generated `help` command, and is useful to your users when they can't remember the syntax of your bot.
 
 The two arguments passed to the command callback are `options` and `callback`. The `options` object contains two attributes: `userName` (your Slack username) and `args` (the arguments passed to the function, as an object). The callback function is the same as the `context.done` function that's built into [lambda](http://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-context.html). The function expects that an error will be passed in as the left argument if there is one, and otherwise a successful execution's response will be passed in as the right argument.
 
 The responses for Slack can either be ephemeral (returning to the user that invoked the function) or in-channel (returning to everyone in the channel in which the function was invoked). SlackBot has a built-in helper for each of these types of responses which are `ephemeralResponse` and `inChannelResponse` respectively. If you pass a string to either one of these functions they return a correctly-formatted object. If you want more fine-grained control, you can pass an object to them and they will set the `response_type` attribute. You can also ignore these functions entirely if you want to return a custom payload.
+
+## Arguments
+
+Commands can optionally have arguments. When commands have arguments, the router will only invoke that command if the number of arguments matches. Arguments are specified as an array in place of the command name, where the command name is the first element of the array. As an example:
+
+```javascript
+slackbot.addCommand(['testing', 'one', 'two'], 'Testing', function (options, callback) {
+  callback(null, this.ephemeralResponse('One: ' + options.args.one + ', Two: ' + options.args.two));
+});
+```
+
+There are three types of arguments: required, optional, and splat. The two arguments in the above command are both required. To specify an optional command use an object where the key is the name of the argument and the value is the optional value. To specify a splat argument (one that will be an array of indeterminant length) append an ellipsis to the end of the name. An example that uses all three is below:
+
+```javascript
+slackbot.addCommand(['echo', 'title', { lastName: 'User' }, 'words...'], 'Respond to the user', function (options, callback) {
+  var response = 'Hello ' + options.args.title + ' ' + options.args.lastName;
+  if (option.args.words.length) {
+    response += ', ' + options.args.words.join(' ');
+  }
+  callback(null, this.ephemeralResponse(response));
+});
+```
 
 ## Routing
 
@@ -62,9 +76,9 @@ It's helpful in testing your function to also export the slackbot itself. If it'
 var expect = require('chai').expect;
   slackBot = require('../slackbot/handler').slackBot;
 
-describe('slackbot', function() {
-  it('responds to ping', function() {
-    var received = false, receivedArgs = [], callback = function(error, success) {
+describe('slackbot', function () {
+  it('responds to ping', function () {
+    var received = false, receivedArgs = [], callback = function (error, success) {
       received = true;
       receivedArgs = [error, success];
     };

--- a/README.md
+++ b/README.md
@@ -40,18 +40,18 @@ The responses for Slack can either be ephemeral (returning to the user that invo
 
 ## Arguments
 
-Commands can optionally have arguments. When commands have arguments, the router will only invoke that command if the number of arguments matches. Arguments are specified as an array in place of the command name, where the command name is the first element of the array. As an example:
+Commands can optionally have arguments. When commands have arguments, the router will only invoke that command if the number of arguments matches. Arguments are specified as an array as the second argument to `addCommand`. As an example:
 
 ```javascript
-slackbot.addCommand(['testing', 'one', 'two'], 'Testing', function (options, callback) {
+slackbot.addCommand('testing', ['one', 'two'], 'Testing', function (options, callback) {
   callback(null, this.ephemeralResponse('One: ' + options.args.one + ', Two: ' + options.args.two));
 });
 ```
 
-There are three types of arguments: required, optional, and splat. The two arguments in the above command are both required. To specify an optional command use an object where the key is the name of the argument and the value is the optional value. To specify a splat argument (one that will be an array of indeterminant length) append an ellipsis to the end of the name. An example that uses all three is below:
+There are three types of arguments: required, optional, and splat. The two arguments in the above command are both required. To specify an optional command use an object with one key where the key is the name of the argument and the value is the optional value. To specify a splat argument (one that will be an array of indeterminant length) append an ellipsis to the end of the name. An example that uses all three is below:
 
 ```javascript
-slackbot.addCommand(['echo', 'title', { lastName: 'User' }, 'words...'], 'Respond to the user', function (options, callback) {
+slackbot.addCommand('echo', ['title', { lastName: 'User' }, 'words...'], 'Respond to the user', function (options, callback) {
   var response = 'Hello ' + options.args.title + ' ' + options.args.lastName;
   if (option.args.words.length) {
     response += ', ' + options.args.words.join(' ');

--- a/index.js
+++ b/index.js
@@ -1,32 +1,9 @@
 'use strict';
 
+var ArgParser = require('./lib/arg-parser');
 var qs = require('qs');
 
 var Utils = {
-  alignArgs: function (argNames, args) {
-    var aligned = {};
-    var givenArgs = args || [];
-    var lastArg = argNames[argNames.length - 1];
-    var splatting = (lastArg && lastArg.match(/\.\.\.$/));
-
-    if ((givenArgs.length < argNames.length) || ((givenArgs.length > argNames.length) && !splatting)) {
-      return false;
-    }
-
-    argNames.slice(0, -1).forEach(function (argName, index) {
-      aligned[argName] = givenArgs[index];
-    });
-    if (lastArg) {
-      if (splatting) {
-        aligned[lastArg.substring(0, lastArg.length - 3)] = givenArgs.slice(argNames.length - 1);
-      } else {
-        aligned[lastArg] = givenArgs[givenArgs.length - 1];
-      }
-    }
-
-    return aligned;
-  },
-
   buildResponse: function (response_type, response) {
     var modifiedResponse = response;
     if (typeof response === 'string') {
@@ -49,10 +26,17 @@ function SlackBot(config) {
 }
 
 // add a command
-SlackBot.prototype.addCommand = function (commandName, desc, command) {
-  var split = Utils.splitCommand(commandName);
-  this[split.commandName] = command;
-  this.commands[split.commandName] = { args: split.args, desc: desc };
+SlackBot.prototype.addCommand = function (command, desc, callback) {
+  var args = [];
+  var commandName = command;
+
+  if (command instanceof Array) {
+    args = command.slice(1);
+    commandName = command[0];
+  }
+
+  this[commandName] = callback;
+  this.commands[commandName] = { args: args, desc: desc };
 };
 
 // call a stored command
@@ -63,7 +47,7 @@ SlackBot.prototype.callCommand = function (commandName, options, callback) {
   if (!this.commands.hasOwnProperty(commandName)) {
     return this.help(options, callback);
   }
-  args = Utils.alignArgs(this.commands[commandName].args, options.args);
+  args = ArgParser.align(this.commands[commandName].args, options.args || []);
   if (args !== false) {
     modifiedOptions.args = args;
     return this[commandName](modifiedOptions, callback);

--- a/index.js
+++ b/index.js
@@ -26,17 +26,19 @@ function SlackBot(config) {
 }
 
 // add a command
-SlackBot.prototype.addCommand = function (command, desc, callback) {
-  var args = [];
-  var commandName = command;
+SlackBot.prototype.addCommand = function (command, args, desc, callback) {
+  var realCallback = callback;
+  var realDesc = desc;
+  var realArgs = args;
 
-  if (command instanceof Array) {
-    args = command.slice(1);
-    commandName = command[0];
+  if (arguments.length === 3) {
+    realCallback = desc;
+    realDesc = args;
+    realArgs = [];
   }
 
-  this[commandName] = callback;
-  this.commands[commandName] = { args: args, desc: desc };
+  this[command] = realCallback;
+  this.commands[command] = { args: realArgs, desc: realDesc };
 };
 
 // call a stored command

--- a/index.js
+++ b/index.js
@@ -31,6 +31,8 @@ SlackBot.prototype.addCommand = function (command, args, desc, callback) {
   var realDesc = desc;
   var realArgs = args;
 
+  // if only 3 arguments are passed, then we're assuming no args are used for
+  // this function, in which case we should shift all of the arguments down one
   if (arguments.length === 3) {
     realCallback = desc;
     realDesc = args;

--- a/lib/arg-parser.js
+++ b/lib/arg-parser.js
@@ -1,0 +1,122 @@
+'use strict';
+
+var Utils = {
+  alignArg: function (aligned, arg, value) {
+    var returnValue = aligned;
+    var optionalArgName;
+
+    switch (this.typeOf(arg)) {
+      case 'opt':
+        optionalArgName = Object.keys(arg)[0];
+        if (typeof value === 'undefined') {
+          returnValue[optionalArgName] = arg[optionalArgName];
+        } else {
+          returnValue[optionalArgName] = value;
+        }
+        break;
+      case 'splat':
+        returnValue = 'splat';
+        break;
+      default:
+        if (typeof value === 'undefined') {
+          return false;
+        }
+        returnValue[arg] = value;
+        break;
+    }
+    return returnValue;
+  },
+
+  minimumRequired: function (args) {
+    return args.filter(function (arg) {
+      return Utils.typeOf(arg) === 'req';
+    }).length;
+  },
+
+  splatPattern: /\.\.\.$/,
+
+  typeOf: function (arg) {
+    if (arg instanceof Object) {
+      return 'opt';
+    }
+    if (arg.match(this.splatPattern)) {
+      return 'splat';
+    }
+    return 'req';
+  }
+};
+
+module.exports = {
+  align: function (args, values) {
+    var aligned = {};
+    var alignArgValue;
+    var argIndex;
+    var splatIndex;
+
+    if (values.length < Utils.minimumRequired(args)) {
+      return false;
+    }
+
+    for (argIndex = 0; argIndex < args.length; argIndex++) {
+      alignArgValue = Utils.alignArg(aligned, args[argIndex], values[argIndex]);
+      if (alignArgValue === false) {
+        return false;
+      } else if (alignArgValue === 'splat') {
+        splatIndex = argIndex;
+        break;
+      }
+      aligned = alignArgValue;
+    }
+
+    if (alignArgValue === 'splat') {
+      args.reverse();
+      values.reverse();
+
+      for (argIndex = 0; argIndex < args.length; argIndex++) {
+        alignArgValue = Utils.alignArg(aligned, args[argIndex], values[argIndex]);
+        if (alignArgValue === false) {
+          return false;
+        } else if (alignArgValue === 'splat') {
+          break;
+        }
+        aligned = alignArgValue;
+      }
+
+      args.reverse();
+      values.reverse();
+      aligned[args[splatIndex].substring(0, args[splatIndex].length - 3)] =
+        values.slice(splatIndex, values.length - argIndex);
+    }
+
+    return aligned;
+  },
+
+  validate: function (args) {
+    var argIndex;
+    var foundOptionalArgs = false;
+    var foundSplattingArgs = false;
+
+    for (argIndex = 0; argIndex < args.length; argIndex++) {
+      switch (Utils.typeOf(args[argIndex])) {
+        case 'opt':
+          if (foundSplattingArgs) {
+            return false; // cannot have optional arguments after a splat
+          }
+          foundOptionalArgs = true;
+          break;
+        case 'splat':
+          if (foundSplattingArgs) {
+            return false; // cannot have two splatting arguments
+          }
+          foundSplattingArgs = true;
+          break;
+        default:
+          if (foundOptionalArgs) {
+            return false; // cannot have required arguments after optional arguments
+          }
+          break;
+      }
+    }
+    return true;
+  }
+};

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "chai": "^3.4.1",
+    "dirty-chai": "^1.2.2",
     "eslint": "^2.2.0",
     "eslint-config-airbnb": "^6.0.2",
     "mocha": "^2.3.4",

--- a/test/arg-parser-test.js
+++ b/test/arg-parser-test.js
@@ -1,0 +1,110 @@
+var chai = require('chai');
+var expect = chai.expect;
+var ArgParser = require('../lib/arg-parser');
+
+chai.use(require('sinon-chai'));
+chai.use(require('dirty-chai'));
+
+describe('arg-parser', function () {
+  describe('align', function () {
+    describe('simple cases', function () {
+      it('correctly aligns when no arguments are expected', function () {
+        expect(ArgParser.align([], [])).to.deep.equal({});
+      });
+
+      it('correctly fails when not enough arguments are given', function () {
+        expect(ArgParser.align(['a', 'b'], [1])).to.be.false();
+      });
+
+      it('aligns direct mappings', function () {
+        expect(ArgParser.align(['a', 'b', 'c'], [1, 2, 3])).to.deep.equal({ a: 1, b: 2, c: 3 });
+      });
+    });
+
+    describe('splatting', function () {
+      it('correctly aligns required arguments before splatting', function () {
+        var args = ['a', 'b', 'c...'];
+        expect(ArgParser.align(args, [1])).to.be.false();
+        expect(ArgParser.align(args, [1, 2])).to.deep.equal({ a: 1, b: 2, c: [] });
+        expect(ArgParser.align(args, [1, 2, 3])).to.deep.equal({ a: 1, b: 2, c: [3] });
+        expect(ArgParser.align(args, [1, 2, 3, 4, 5])).to.deep.equal({ a: 1, b: 2, c: [3, 4, 5] });
+      });
+
+      it('correctly aligns required arguments around splatting', function () {
+        var args = ['a', 'b', 'c...', 'd', 'e'];
+        expect(ArgParser.align(args, [1, 2, 3])).to.be.false();
+        expect(ArgParser.align(args, [1, 2, 3, 4])).to.deep.equal({ a: 1, b: 2, c: [], d: 3, e: 4 });
+        expect(ArgParser.align(args, [1, 2, 3, 4, 5])).to.deep.equal({ a: 1, b: 2, c: [3], d: 4, e: 5 });
+        expect(ArgParser.align(args, [1, 2, 3, 4, 5, 6, 7])).to.deep.equal({ a: 1, b: 2, c: [3, 4, 5], d: 6, e: 7 });
+      });
+    });
+
+    describe('optional', function () {
+      it('allows objects to be passed instead of strings', function () {
+        expect(ArgParser.align(['a', { b: 2 }], [1])).to.deep.equal({ a: 1, b: 2 });
+      });
+
+      it('correctly overrides defaults when a value is given', function () {
+        expect(ArgParser.align(['a', { b: 2 }], [1, 3])).to.deep.equal({ a: 1, b: 3 });
+      });
+
+      it('functions when no values are passed for all optional arguments', function () {
+        expect(ArgParser.align([{ a: 1 }, { b: 2 }], [])).to.deep.equal({ a: 1, b: 2 });
+      });
+    });
+  });
+
+  describe('validate', function () {
+    describe('positive cases', function () {
+      it('base case', function () {
+        expect(ArgParser.validate([])).to.be.true();
+      });
+
+      it('only required arguments', function () {
+        expect(ArgParser.validate(['a', 'b', 'c'])).to.be.true();
+      });
+
+      it('all optional arguments', function () {
+        expect(ArgParser.validate([{ a: 1 }, { b: 2 }])).to.be.true();
+      });
+
+      it('required and optional arguments', function () {
+        expect(ArgParser.validate(['a', 'b', { c: 3 }, { d: 4 }])).to.be.true();
+      });
+
+      it('just splatting', function () {
+        expect(ArgParser.validate(['a...'])).to.be.true();
+      });
+
+      it('required arguments and splatting on end', function () {
+        expect(ArgParser.validate(['a', 'b', 'c...'])).to.be.true();
+      });
+
+      it('required arguments around splatting', function () {
+        expect(ArgParser.validate(['a', 'b...', 'c'])).to.be.true();
+      });
+
+      it('required arguments after splatting', function () {
+        expect(ArgParser.validate(['a...', 'b', 'c'])).to.be.true();
+      });
+
+      it('required arguments, optional arguments, and splatting', function () {
+        expect(ArgParser.validate(['a', 'b', { c: 3 }, { d: 4 }, 'e...'])).to.be.true();
+      });
+    });
+
+    describe('negative cases', function () {
+      it('double splatting', function () {
+        expect(ArgParser.validate(['a...', 'b', 'c...'])).to.be.false();
+      });
+
+      it('required arguments around optional arguments', function () {
+        expect(ArgParser.validate(['a', { b: 2 }, 'c'])).to.be.false();
+      });
+
+      it('splatting before optional argument', function () {
+        expect(ArgParser.validate(['a...', { b: 2 }])).to.be.false();
+      });
+    });
+  });
+});

--- a/test/commands-test.js
+++ b/test/commands-test.js
@@ -22,7 +22,7 @@ describe('managing commands', function () {
   });
 
   it('adds a command with the correct arguments', function () {
-    slackbot.addCommand(['test', 'arg1', 'arg2'], 'The test command', testCommand);
+    slackbot.addCommand('test', ['arg1', 'arg2'], 'The test command', testCommand);
 
     expect(slackbot.test).to.equal(testCommand);
     expect(slackbot.commands.test.args).to.deep.equal(['arg1', 'arg2']);
@@ -45,7 +45,7 @@ describe('managing commands', function () {
     var spiedFunction = sinon.stub(slackbot, 'help');
     var callback = function () {};
 
-    slackbot.addCommand(['test', 'arg1'], 'test function', testCommand);
+    slackbot.addCommand('test', ['arg1'], 'test function', testCommand);
     slackbot.callCommand('test', {}, callback);
 
     expect(spiedFunction).to.have.been.calledWithExactly({}, callback);

--- a/test/commands-test.js
+++ b/test/commands-test.js
@@ -1,0 +1,53 @@
+var sinon = require('sinon');
+var chai = require('chai');
+var expect = chai.expect;
+var SlackBot = require('../index');
+
+chai.use(require('sinon-chai'));
+
+describe('managing commands', function () {
+  var slackbot;
+  var testCommand;
+
+  beforeEach(function () {
+    slackbot = new SlackBot();
+    testCommand = function () {};
+  });
+
+  it('adds a command with the correct description', function () {
+    slackbot.addCommand('test', 'The test command', testCommand);
+
+    expect(slackbot.test).to.equal(testCommand);
+    expect(slackbot.commands.test.desc).to.equal('The test command');
+  });
+
+  it('adds a command with the correct arguments', function () {
+    slackbot.addCommand(['test', 'arg1', 'arg2'], 'The test command', testCommand);
+
+    expect(slackbot.test).to.equal(testCommand);
+    expect(slackbot.commands.test.args).to.deep.equal(['arg1', 'arg2']);
+  });
+
+  it('calls the correct command with the correct arguments', function () {
+    var spiedFunction = sinon.spy();
+    var callback = function () {};
+    var givenArgs;
+
+    slackbot.addCommand('test', 'test function', spiedFunction);
+    slackbot.callCommand('test', {}, callback);
+
+    givenArgs = spiedFunction.getCall(0).args;
+    expect(givenArgs[0]).to.deep.equal({ args: {} });
+    expect(givenArgs[1]).to.equal(callback);
+  });
+
+  it('restricts calling without the correct number of arguments', function () {
+    var spiedFunction = sinon.stub(slackbot, 'help');
+    var callback = function () {};
+
+    slackbot.addCommand(['test', 'arg1'], 'test function', testCommand);
+    slackbot.callCommand('test', {}, callback);
+
+    expect(spiedFunction).to.have.been.calledWithExactly({}, callback);
+  });
+});

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -1,92 +1,13 @@
 var sinon = require('sinon');
 var chai = require('chai');
 var expect = chai.expect;
-var SlackBot = require('./index');
+var SlackBot = require('../index');
 
 chai.use(require('sinon-chai'));
 
-describe('responses', function () {
-  it('responds with the correct ephemeral response format', function () {
-    expect(new SlackBot().ephemeralResponse('foo')).to.deep.equal({
-      response_type: 'ephemeral',
-      text: 'foo'
-    });
-  });
-
-  it('responds with the correct in-channel response format', function () {
-    expect(new SlackBot().inChannelResponse('bar')).to.deep.equal({
-      response_type: 'in_channel',
-      text: 'bar'
-    });
-  });
-
-  it('adds attachments appropriately', function () {
-    var response = new SlackBot().ephemeralResponse({
-      text: 'test',
-      attachments: [{
-        text: 'attachment'
-      }]
-    });
-
-    expect(response).to.deep.equal({
-      response_type: 'ephemeral',
-      text: 'test',
-      attachments: [{ text: 'attachment' }]
-    });
-  });
-});
-
-describe('managing commands', function () {
-  var slackbot;
-  var testCommand;
-
-  beforeEach(function () {
-    slackbot = new SlackBot();
-    testCommand = function () {};
-  });
-
-  it('adds a command with the correct description', function () {
-    slackbot.addCommand('test', 'The test command', testCommand);
-
-    expect(slackbot.test).to.equal(testCommand);
-    expect(slackbot.commands.test.desc).to.equal('The test command');
-  });
-
-  it('adds a command with the correct arguments', function () {
-    slackbot.addCommand('test arg1 arg2', 'The test command', testCommand);
-
-    expect(slackbot.test).to.equal(testCommand);
-    expect(slackbot.commands.test.args).to.deep.equal(['arg1', 'arg2']);
-  });
-
-  it('calls the correct command with the correct arguments', function () {
-    var spiedFunction = sinon.spy();
-    var callback = function () {};
-    var givenArgs;
-
-    slackbot.addCommand('test', 'test function', spiedFunction);
-    slackbot.callCommand('test', {}, callback);
-
-    givenArgs = spiedFunction.getCall(0).args;
-    expect(givenArgs[0]).to.deep.equal({ args: {} });
-    expect(givenArgs[1]).to.equal(callback);
-  });
-
-  it('restricts calling without the correct number of arguments', function () {
-    var spiedFunction = sinon.stub(slackbot, 'help');
-    var callback = function () {};
-
-    slackbot.addCommand('test arg1', 'test function', testCommand);
-    slackbot.callCommand('test', {}, callback);
-
-    expect(spiedFunction).to.have.been.calledWithExactly({}, callback);
-  });
-});
-
-describe('buildRouter', function () {
+describe('integration', function () {
   var context = {};
   var slackbot = new SlackBot({ token: 'token' });
-
   var assertHelp = function (event, commandContext) {
     var descriptions = [
       'testA: Test command A',
@@ -106,10 +27,10 @@ describe('buildRouter', function () {
   slackbot.addCommand('testA', 'Test command A', function (options, cb) {
     cb(null, this.ephemeralResponse('A response'));
   });
-  slackbot.addCommand('testB arg1 arg2', 'Test command B', function (options, cb) {
+  slackbot.addCommand(['testB', 'arg1', 'arg2'], 'Test command B', function (options, cb) {
     cb(null, this.ephemeralResponse('B response'));
   });
-  slackbot.addCommand('testC arg1 arg2...', 'Test command C', function (options, cb) {
+  slackbot.addCommand(['testC', 'arg1', 'arg2...'], 'Test command C', function (options, cb) {
     cb(null, this.ephemeralResponse(options.args.arg2.join(' ')));
   });
 

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -6,125 +6,161 @@ var SlackBot = require('../index');
 chai.use(require('sinon-chai'));
 
 describe('integration', function () {
-  var context = {};
-  var slackbot = new SlackBot({ token: 'token' });
-  var assertHelp = function (event, commandContext) {
-    var descriptions = [
-      'testA: Test command A',
-      'testB arg1 arg2: Test command B',
-      'testC arg1 arg2...: Test command C',
-      'help: display this help message'
-    ];
+  describe('testbot', function () {
+    var context = {};
+    var slackbot = new SlackBot({ token: 'token' });
+    var assertHelp = function (event, commandContext) {
+      var descriptions = [
+        'testA: Test command A',
+        'testB arg1 arg2: Test command B',
+        'testC arg1 arg2...: Test command C',
+        'help: display this help message'
+      ];
 
-    slackbot.buildRouter()(event, commandContext);
-    expect(commandContext.done).to.have.been.calledWithExactly(null, {
-      text: 'Available commands:',
-      attachments: [{ text: descriptions.join('\n') }],
-      response_type: 'ephemeral'
+      slackbot.buildRouter()(event, commandContext);
+      expect(commandContext.done).to.have.been.calledWithExactly(null, {
+        text: 'Available commands:',
+        attachments: [{ text: descriptions.join('\n') }],
+        response_type: 'ephemeral'
+      });
+    };
+
+    slackbot.addCommand('testA', 'Test command A', function (options, cb) {
+      cb(null, this.ephemeralResponse('A response'));
     });
-  };
+    slackbot.addCommand(['testB', 'arg1', 'arg2'], 'Test command B', function (options, cb) {
+      cb(null, this.ephemeralResponse('B response'));
+    });
+    slackbot.addCommand(['testC', 'arg1', 'arg2...'], 'Test command C', function (options, cb) {
+      cb(null, this.ephemeralResponse(options.args.arg2.join(' ')));
+    });
 
-  slackbot.addCommand('testA', 'Test command A', function (options, cb) {
-    cb(null, this.ephemeralResponse('A response'));
-  });
-  slackbot.addCommand(['testB', 'arg1', 'arg2'], 'Test command B', function (options, cb) {
-    cb(null, this.ephemeralResponse('B response'));
-  });
-  slackbot.addCommand(['testC', 'arg1', 'arg2...'], 'Test command C', function (options, cb) {
-    cb(null, this.ephemeralResponse(options.args.arg2.join(' ')));
-  });
+    beforeEach(function () {
+      context.done = sinon.spy();
+    });
 
-  beforeEach(function () {
-    context.done = sinon.spy();
-  });
+    it('fails when the provided token is invalid', function () {
+      var event = {
+        body: {
+          token: 'foo',
+          text: 'help'
+        }
+      };
+      slackbot.buildRouter()(event, context);
 
-  it('fails when the provided token is invalid', function () {
-    var event = {
-      body: {
-        token: 'foo',
-        text: 'help'
-      }
-    };
-    slackbot.buildRouter()(event, context);
+      expect(context.done).to.have.been.calledWithExactly({
+        text: 'Invalid Slack token',
+        response_type: 'ephemeral'
+      });
+    });
 
-    expect(context.done).to.have.been.calledWithExactly({
-      text: 'Invalid Slack token',
-      response_type: 'ephemeral'
+    it('responds with help text', function () {
+      var event = {
+        body: {
+          token: 'token',
+          text: 'help'
+        }
+      };
+      assertHelp(event, context);
+    });
+
+    it('routes to the help text by default', function () {
+      var event = {
+        body: {
+          token: 'token',
+          text: ''
+        }
+      };
+      assertHelp(event, context);
+    });
+
+    it('routes to the help text when invalid command is specified', function () {
+      var event = {
+        body: {
+          token: 'token',
+          text: 'invalid'
+        }
+      };
+      assertHelp(event, context);
+    });
+
+    it('routes to the appropriate command name', function () {
+      var event = {
+        body: {
+          token: 'token',
+          text: 'testA'
+        }
+      };
+      slackbot.buildRouter()(event, context);
+
+      expect(context.done).to.have.been.calledWithExactly(null, {
+        text: 'A response',
+        response_type: 'ephemeral'
+      });
+    });
+
+    it('supports splatting the last argument', function () {
+      var event = {
+        body: {
+          token: 'token',
+          text: 'testC these are all my words'
+        }
+      };
+      slackbot.buildRouter()(event, context);
+
+      expect(context.done).to.have.been.calledWithExactly(null, {
+        text: 'are all my words',
+        response_type: 'ephemeral'
+      });
+    });
+
+    it('correctly splats when only one argument is given', function () {
+      var event = {
+        body: {
+          token: 'token',
+          text: 'testC arg1 arg2'
+        }
+      };
+      slackbot.buildRouter()(event, context);
+
+      expect(context.done).to.have.been.calledWithExactly(null, {
+        text: 'arg2',
+        response_type: 'ephemeral'
+      });
     });
   });
 
-  it('responds with help text', function () {
-    var event = {
-      body: {
-        token: 'token',
-        text: 'help'
-      }
-    };
-    assertHelp(event, context);
-  });
+  describe('examples', function () {
+    var context = {};
 
-  it('routes to the help text by default', function () {
-    var event = {
-      body: {
-        token: 'token',
-        text: ''
-      }
-    };
-    assertHelp(event, context);
-  });
+    var slackbot = new SlackBot({ token: 'token' });
+    var args = ['echo', 'title', { lastName: 'User' }, 'words...'];
 
-  it('routes to the help text when invalid command is specified', function () {
-    var event = {
-      body: {
-        token: 'token',
-        text: 'invalid'
+    slackbot.addCommand(args, 'Greetings', function (options, callback) {
+      var response = 'Hello ' + options.args.title + ' ' + options.args.lastName;
+      if (options.args.words.length) {
+        response += ', ' + options.args.words.join(' ');
       }
-    };
-    assertHelp(event, context);
-  });
-
-  it('routes to the appropriate command name', function () {
-    var event = {
-      body: {
-        token: 'token',
-        text: 'testA'
-      }
-    };
-    slackbot.buildRouter()(event, context);
-
-    expect(context.done).to.have.been.calledWithExactly(null, {
-      text: 'A response',
-      response_type: 'ephemeral'
+      callback(null, this.ephemeralResponse(response));
     });
-  });
 
-  it('supports splatting the last argument', function () {
-    var event = {
-      body: {
-        token: 'token',
-        text: 'testC these are all my words'
-      }
-    };
-    slackbot.buildRouter()(event, context);
-
-    expect(context.done).to.have.been.calledWithExactly(null, {
-      text: 'are all my words',
-      response_type: 'ephemeral'
+    beforeEach(function () {
+      context.done = sinon.spy();
     });
-  });
 
-  it('correctly splats when only one argument is given', function () {
-    var event = {
-      body: {
-        token: 'token',
-        text: 'testC arg1 arg2'
-      }
-    };
-    slackbot.buildRouter()(event, context);
+    it('returns the expected response', function () {
+      var event = {
+        body: {
+          token: 'token',
+          text: 'echo Sir User how are you today?'
+        }
+      };
+      slackbot.buildRouter()(event, context);
 
-    expect(context.done).to.have.been.calledWithExactly(null, {
-      text: 'arg2',
-      response_type: 'ephemeral'
+      expect(context.done).to.have.been.calledWithExactly(null, {
+        text: 'Hello Sir User, how are you today?',
+        response_type: 'ephemeral'
+      });
     });
   });
 });

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -28,10 +28,10 @@ describe('integration', function () {
     slackbot.addCommand('testA', 'Test command A', function (options, cb) {
       cb(null, this.ephemeralResponse('A response'));
     });
-    slackbot.addCommand(['testB', 'arg1', 'arg2'], 'Test command B', function (options, cb) {
+    slackbot.addCommand('testB', ['arg1', 'arg2'], 'Test command B', function (options, cb) {
       cb(null, this.ephemeralResponse('B response'));
     });
-    slackbot.addCommand(['testC', 'arg1', 'arg2...'], 'Test command C', function (options, cb) {
+    slackbot.addCommand('testC', ['arg1', 'arg2...'], 'Test command C', function (options, cb) {
       cb(null, this.ephemeralResponse(options.args.arg2.join(' ')));
     });
 
@@ -134,9 +134,9 @@ describe('integration', function () {
     var context = {};
 
     var slackbot = new SlackBot({ token: 'token' });
-    var args = ['echo', 'title', { lastName: 'User' }, 'words...'];
+    var args = ['title', { lastName: 'User' }, 'words...'];
 
-    slackbot.addCommand(args, 'Greetings', function (options, callback) {
+    slackbot.addCommand('echo', args, 'Greetings', function (options, callback) {
       var response = 'Hello ' + options.args.title + ' ' + options.args.lastName;
       if (options.args.words.length) {
         response += ', ' + options.args.words.join(' ');

--- a/test/responses-test.js
+++ b/test/responses-test.js
@@ -1,0 +1,34 @@
+var chai = require('chai');
+var expect = chai.expect;
+var SlackBot = require('../index');
+
+describe('responses', function () {
+  it('responds with the correct ephemeral response format', function () {
+    expect(new SlackBot().ephemeralResponse('foo')).to.deep.equal({
+      response_type: 'ephemeral',
+      text: 'foo'
+    });
+  });
+
+  it('responds with the correct in-channel response format', function () {
+    expect(new SlackBot().inChannelResponse('bar')).to.deep.equal({
+      response_type: 'in_channel',
+      text: 'bar'
+    });
+  });
+
+  it('adds attachments appropriately', function () {
+    var response = new SlackBot().ephemeralResponse({
+      text: 'test',
+      attachments: [{
+        text: 'attachment'
+      }]
+    });
+
+    expect(response).to.deep.equal({
+      response_type: 'ephemeral',
+      text: 'test',
+      attachments: [{ text: 'attachment' }]
+    });
+  });
+});


### PR DESCRIPTION
This is a breaking change that will allow optional arguments to be specified
for commands. As such, the manner in which you specify arguments needed to change
as well. Before you would specify them as part of the command name string:

    slackbot.addCommand('testing one two three', 'The test command', function() {});

now you specify them as an array:

    slackbot.addCommand(['testing', 'one', 'two', 'three'], 'The test command', function() {});

This paves the way for having commands that match multiple words instead of one.
It also allows us to specify optional arguments as:

    slackbot.addCommand(['testing', 'one', { two: 2 }], 'The test command', function() {});