### PR TITLE
Fix optional args help message

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,9 +75,18 @@ SlackBot.prototype.help = function (options, callback) {
 
   Object.keys(this.commands).forEach(function (command) {
     helpText += command;
+
     if (this.commands[command].args.length) {
-      helpText += ' ' + this.commands[command].args.join(' ');
+      helpText += ' ' + this.commands[command].args.map(function (arg) {
+        var optionalArgName;
+        if (arg instanceof Object) {
+          optionalArgName = Object.keys(arg)[0];
+          return optionalArgName + ':' + arg[optionalArgName];
+        }
+        return arg.toString();
+      }).join(' ');
     }
+
     helpText += ': ' + this.commands[command].desc + '\n';
   }.bind(this));
   helpText += 'help: display this help message';

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -12,7 +12,7 @@ describe('integration', function () {
     var assertHelp = function (event, commandContext) {
       var descriptions = [
         'testA: Test command A',
-        'testB arg1 arg2: Test command B',
+        'testB arg1 arg2 arg3:3: Test command B',
         'testC arg1 arg2...: Test command C',
         'help: display this help message'
       ];
@@ -28,7 +28,7 @@ describe('integration', function () {
     slackbot.addCommand('testA', 'Test command A', function (options, cb) {
       cb(null, this.ephemeralResponse('A response'));
     });
-    slackbot.addCommand('testB', ['arg1', 'arg2'], 'Test command B', function (options, cb) {
+    slackbot.addCommand('testB', ['arg1', 'arg2', { arg3: 3 }], 'Test command B', function (options, cb) {
       cb(null, this.ephemeralResponse('B response'));
     });
     slackbot.addCommand('testC', ['arg1', 'arg2...'], 'Test command C', function (options, cb) {


### PR DESCRIPTION
Because optional arguments are now supported, we need to change the
help message to reflect that. The help text for a function like:

    sb.addCommand('test', ['one', { two: 2 }, 'three...'], 'desc', function () {});

now looks like:

    test one two:2 three...: desc