### PR TITLE
Allow for further configuring arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,73 +41,7 @@ The responses for Slack can either be ephemeral (returning to the user that invo
 
 ## Arguments
 
-Commands can optionally have arguments. When commands have arguments, the router will only invoke that command if the number of arguments matches. Arguments are specified as an array as the second argument to `addCommand`. As an example:
-
-```javascript
-slackbot.addCommand('testing', ['one', 'two'], 'Testing', function (options, callback) {
-  callback(null, this.ephemeralResponse('One: ' + options.args.one + ', Two: ' + options.args.two));
-});
-```
-
-There are four types of arguments: required, optional, splat, and configured.
-
-#### Required
-
-The two arguments in the above command are both required.
-
-#### Optional
-
-To specify an optional argument, use an object with one key, where the key is the name of the argument and the value is the default value.
-
-```javascript
-slackbot.addCommand('testing', [{ one: 'default' }], 'Testing', function (options, callback) {
-  callback(null, this.ephemeralResponse('One: ' + options.args.one));
-});
-```
-
-#### Splat
-
-To specify a splat argument (one that will be an array of indeterminant length), append an ellipsis to the end of the name.
-
-```javascript
-slackbot.addCommand('testing', ['words...'], 'Testing', function (options, callback) {
-  callback(null, this.ephemeralResponse('Words: ' + options.args.words.join(' ')));
-});
-```
-
-#### Configured
-
-To specify a configured argument, use a nested object with one key, where the key is the name of the argument and the value is the argument options. The available options are `default`, which allows for providing a default value for the argument, and `restrict`, which lets you restrict what values are allowed.
-
-The value of the `restrict` parameter can be a string, number, or array. If it is an array, the value will be permitted if it matches any element in the array. If the value that the user passes does not match the restricted value, an error will be thrown.
-
-```javascript
-slackbot.addCommand('test-one', [{ one: { default: 'default' } }], 'Testing', function (options, callback) {
-  callback(null, this.ephemeralResponse('One: ' + options.args.one));
-});
-
-slackbot.addCommand('test-two', [{ one: { restrict: ['foo', 'bar'] } }], 'Testing', function (options, callback) {
-  callback(null, this.ephemeralResponse('One: ' + options.args.one));
-});
-```
-
-#### Putting it all together
-
-An example that uses all four types of arguments is below:
-
-```javascript
-slackbot.addCommand(
-  'echo',
-  ['title', { firstName: 'John' }, { lastName: { default: 'Smith', restrict: ['Jones', 'Smith'] } } 'words...'],
-  'Respond to the user',
-  function (options, callback) {
-    var response = 'Hello ' + options.args.title + ' ' options.args.firstName + ' ' + options.args.lastName;
-    if (option.args.words.length) {
-      response += ', ' + options.args.words.join(' ');
-    }
-    callback(null, this.ephemeralResponse(response));
-  });
-```
+See [Arguments.md](doc/Arguments.md) for instructions on specifying command arguments.
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -49,16 +49,64 @@ slackbot.addCommand('testing', ['one', 'two'], 'Testing', function (options, cal
 });
 ```
 
-There are three types of arguments: required, optional, and splat. The two arguments in the above command are both required. To specify an optional command use an object with one key where the key is the name of the argument and the value is the optional value. To specify a splat argument (one that will be an array of indeterminant length) append an ellipsis to the end of the name. An example that uses all three is below:
+There are four types of arguments: required, optional, splat, and configured.
+
+#### Required
+
+The two arguments in the above command are both required.
+
+#### Optional
+
+To specify an optional argument, use an object with one key, where the key is the name of the argument and the value is the default value.
 
 ```javascript
-slackbot.addCommand('echo', ['title', { lastName: 'User' }, 'words...'], 'Respond to the user', function (options, callback) {
-  var response = 'Hello ' + options.args.title + ' ' + options.args.lastName;
-  if (option.args.words.length) {
-    response += ', ' + options.args.words.join(' ');
-  }
-  callback(null, this.ephemeralResponse(response));
+slackbot.addCommand('testing', [{ one: 'default' }], 'Testing', function (options, callback) {
+  callback(null, this.ephemeralResponse('One: ' + options.args.one));
 });
+```
+
+#### Splat
+
+To specify a splat argument (one that will be an array of indeterminant length), append an ellipsis to the end of the name.
+
+```javascript
+slackbot.addCommand('testing', ['words...'], 'Testing', function (options, callback) {
+  callback(null, this.ephemeralResponse('Words: ' + options.args.words.join(' ')));
+});
+```
+
+#### Configured
+
+To specify a configured argument, use a nested object with one key, where the key is the name of the argument and the value is the argument options. The available options are `default`, which allows for providing a default value for the argument, and `restrict`, which lets you restrict what values are allowed.
+
+The value of the `restrict` parameter can be a string, number, or array. If it is an array, the value will be permitted if it matches any element in the array. If the value that the user passes does not match the restricted value, an error will be thrown.
+
+```javascript
+slackbot.addCommand('test-one', [{ one: { default: 'default' } }], 'Testing', function (options, callback) {
+  callback(null, this.ephemeralResponse('One: ' + options.args.one));
+});
+
+slackbot.addCommand('test-two', [{ one: { restrict: ['foo', 'bar'] } }], 'Testing', function (options, callback) {
+  callback(null, this.ephemeralResponse('One: ' + options.args.one));
+});
+```
+
+#### Putting it all together
+
+An example that uses all four types of arguments is below:
+
+```javascript
+slackbot.addCommand(
+  'echo',
+  ['title', { firstName: 'John' }, { lastName: { default: 'Smith', restrict: ['Jones', 'Smith'] } } 'words...'],
+  'Respond to the user',
+  function (options, callback) {
+    var response = 'Hello ' + options.args.title + ' ' options.args.firstName + ' ' + options.args.lastName;
+    if (option.args.words.length) {
+      response += ', ' + options.args.words.join(' ');
+    }
+    callback(null, this.ephemeralResponse(response));
+  });
 ```
 
 ## Routing

--- a/doc/Arguments.md
+++ b/doc/Arguments.md
@@ -1,0 +1,69 @@
+# Command Arguments
+
+Commands can optionally have arguments. When commands have arguments, the router will only invoke that command if the number of arguments matches. Arguments are specified as an array as the second argument to `addCommand`. As an example:
+
+```javascript
+slackbot.addCommand('testing', ['one', 'two'], 'Testing', function (options, callback) {
+  callback(null, this.ephemeralResponse('One: ' + options.args.one + ', Two: ' + options.args.two));
+});
+```
+
+There are four types of arguments: required, optional, splat, and configured.
+
+## Required
+
+The two arguments in the above command are both required.
+
+## Optional
+
+To specify an optional argument, use an object with one key, where the key is the name of the argument and the value is the default value.
+
+```javascript
+slackbot.addCommand('testing', [{ one: 'default' }], 'Testing', function (options, callback) {
+  callback(null, this.ephemeralResponse('One: ' + options.args.one));
+});
+```
+
+## Splat
+
+To specify a splat argument (one that will be an array of indeterminant length), append an ellipsis to the end of the name.
+
+```javascript
+slackbot.addCommand('testing', ['words...'], 'Testing', function (options, callback) {
+  callback(null, this.ephemeralResponse('Words: ' + options.args.words.join(' ')));
+});
+```
+
+## Configured
+
+To specify a configured argument, use a nested object with one key, where the key is the name of the argument and the value is the argument options. The available options are `default`, which allows for providing a default value for the argument, and `restrict`, which lets you restrict what values are allowed.
+
+The value of the `restrict` parameter can be a string, number, or array. If it is an array, the value will be permitted if it matches any element in the array. If the value that the user passes does not match the restricted value, an error will be thrown.
+
+```javascript
+slackbot.addCommand('test-one', [{ one: { default: 'default' } }], 'Testing', function (options, callback) {
+  callback(null, this.ephemeralResponse('One: ' + options.args.one));
+});
+
+slackbot.addCommand('test-two', [{ one: { restrict: ['foo', 'bar'] } }], 'Testing', function (options, callback) {
+  callback(null, this.ephemeralResponse('One: ' + options.args.one));
+});
+```
+
+## Putting it all together
+
+An example that uses all four types of arguments is below:
+
+```javascript
+slackbot.addCommand(
+  'echo',
+  ['title', { firstName: 'John' }, { lastName: { default: 'Smith', restrict: ['Jones', 'Smith'] } }, 'words...'],
+  'Respond to the user',
+  function (options, callback) {
+    var response = 'Hello ' + options.args.title + ' ' + options.args.firstName + ' ' + options.args.lastName;
+    if (option.args.words.length) {
+      response += ', ' + options.args.words.join(' ');
+    }
+    callback(null, this.ephemeralResponse(response));
+  });
+```

--- a/index.js
+++ b/index.js
@@ -93,9 +93,30 @@ SlackBot.prototype.help = function (options, callback) {
     if (this.commands[command].args.length) {
       helpText += ' ' + this.commands[command].args.map(function (arg) {
         var optionalArgName;
-        if (arg instanceof Object) {
+        var configuredArgName;
+        var configuredArgOpts;
+        var configuredArgHelpText;
+        var argType = ArgParser.typeOf(arg);
+        if (argType === 'opt') {
           optionalArgName = Object.keys(arg)[0];
-          return optionalArgName + ':' + arg[optionalArgName];
+          return '[' + optionalArgName + ':' + arg[optionalArgName] + ']';
+        } else if (argType === 'configured') {
+          configuredArgName = Object.keys(arg)[0];
+          configuredArgOpts = arg[configuredArgName];
+          configuredArgHelpText = '';
+          if (configuredArgOpts.default) {
+            configuredArgHelpText = '[' + configuredArgName + ':' + configuredArgOpts.default + ']';
+          } else {
+            configuredArgHelpText = configuredArgName;
+          }
+          if (configuredArgOpts.restrict) {
+            if (configuredArgOpts.restrict instanceof Array) {
+              configuredArgHelpText += ' (' + configuredArgOpts.restrict.join('|') + ')';
+            } else {
+              configuredArgHelpText += ' (' + configuredArgOpts.restrict.toString() + ')';
+            }
+          }
+          return configuredArgHelpText;
         }
         return arg.toString();
       }).join(' ');

--- a/index.js
+++ b/index.js
@@ -95,7 +95,8 @@ SlackBot.prototype.help = function (options, callback) {
         var optionalArgName;
         var configuredArgName;
         var configuredArgOpts;
-        var configuredArgHelpText;
+        var configuredArgHelpText = '';
+        var configuredArgRestrictText = '';
         var argType = ArgParser.typeOf(arg);
         if (argType === 'opt') {
           optionalArgName = Object.keys(arg)[0];
@@ -103,19 +104,20 @@ SlackBot.prototype.help = function (options, callback) {
         } else if (argType === 'configured') {
           configuredArgName = Object.keys(arg)[0];
           configuredArgOpts = arg[configuredArgName];
-          configuredArgHelpText = '';
-          if (configuredArgOpts.default) {
-            configuredArgHelpText = '[' + configuredArgName + ':' + configuredArgOpts.default + ']';
-          } else {
-            configuredArgHelpText = configuredArgName;
-          }
           if (configuredArgOpts.restrict) {
             if (configuredArgOpts.restrict instanceof Array) {
-              configuredArgHelpText += ' (' + configuredArgOpts.restrict.join('|') + ')';
+              configuredArgRestrictText = ' (' + configuredArgOpts.restrict.join('|') + ')';
             } else {
-              configuredArgHelpText += ' (' + configuredArgOpts.restrict.toString() + ')';
+              configuredArgRestrictText = ' (' + configuredArgOpts.restrict.toString() + ')';
             }
           }
+          if (configuredArgOpts.default) {
+            configuredArgHelpText = '[' + configuredArgName + ':' +
+              configuredArgOpts.default + ' ' + configuredArgRestrictText + ']';
+          } else {
+            configuredArgHelpText = configuredArgName + configuredArgRestrictText;
+          }
+
           return configuredArgHelpText;
         }
         return arg.toString();

--- a/lib/arg-parser.js
+++ b/lib/arg-parser.js
@@ -156,5 +156,9 @@ module.exports = {
       }
     }
     return true;
+  },
+
+  typeOf: function (arg) {
+    return Utils.typeOf(arg);
   }
 };

--- a/lib/arg-parser.js
+++ b/lib/arg-parser.js
@@ -1,9 +1,20 @@
 'use strict';
 
 var Utils = {
+  isString: function (val) {
+    return typeof val === 'string' || val instanceof String;
+  },
+
+  isNumber: function (val) {
+    return typeof val === 'number';
+  },
+
   alignArg: function (aligned, arg, value) {
     var returnValue = aligned;
     var optionalArgName;
+    var configuredArgName;
+    var configuredArgOpts;
+    var restrict;
 
     switch (this.typeOf(arg)) {
       case 'opt':
@@ -16,6 +27,27 @@ var Utils = {
         break;
       case 'splat':
         returnValue = 'splat';
+        break;
+      case 'configured':
+        configuredArgName = Object.keys(arg)[0];
+        configuredArgOpts = arg[configuredArgName];
+        if (configuredArgOpts.default && typeof value === 'undefined') {
+          returnValue[configuredArgName] = configuredArgOpts.default;
+        } else {
+          restrict = configuredArgOpts.restrict;
+          if (restrict instanceof Array) {
+            if (restrict.indexOf(value) === -1) {
+              return false;
+            }
+          } else if ((Utils.isString(restrict) || Utils.isNumber(restrict))) {
+            if (value !== restrict) {
+              return false;
+            }
+          } else if (typeof restrict !== 'undefined') {
+            throw new TypeError('Argument restriction must be a string, number, or array');
+          }
+          returnValue[configuredArgName] = value;
+        }
         break;
       default:
         if (typeof value === 'undefined') {
@@ -36,7 +68,13 @@ var Utils = {
   splatPattern: /\.\.\.$/,
 
   typeOf: function (arg) {
+    var argName;
+
     if (arg instanceof Object) {
+      argName = Object.keys(arg)[0];
+      if (arg[argName] instanceof Object) {
+        return 'configured';
+      }
       return 'opt';
     }
     if (arg.match(this.splatPattern)) {

--- a/test/arg-parser-test.js
+++ b/test/arg-parser-test.js
@@ -52,6 +52,44 @@ describe('arg-parser', function () {
         expect(ArgParser.align([{ a: 1 }, { b: 2 }], [])).to.deep.equal({ a: 1, b: 2 });
       });
     });
+
+    describe('configured', function () {
+      it('allows nested objects to be passed instead of strings', function () {
+        expect(ArgParser.align(['a', { b: {} }], [1, 2])).to.deep.equal({ a: 1, b: 2 });
+      });
+
+      it('allows a default value in the nested object', function () {
+        expect(ArgParser.align(['a', { b: { default: 2 } }], [1])).to.deep.equal({ a: 1, b: 2 });
+      });
+
+      it('allows for restricting the value in the nested object', function () {
+        expect(ArgParser.align(['a', { b: { restrict: 2 } }], [1, 2])).to.deep.equal({ a: 1, b: 2 });
+      });
+
+      it('can restrict the value to a number', function () {
+        expect(ArgParser.align(['a', { b: { restrict: 2 } }], [1, 3])).to.be.false();
+      });
+
+      it('can restrict the value to a string', function () {
+        expect(ArgParser.align(['a', { b: { restrict: 'c' } }], [1, 'd'])).to.be.false();
+      });
+
+      it('can restrict the value to an array of values', function () {
+        expect(ArgParser.align(['a', { b: { restrict: [2, 3, 4] } }], [1, 5])).to.be.false();
+      });
+
+      it('correctly overrides defaults when a value is given', function () {
+        expect(ArgParser.align(['a', { b: { default: 2 } }], [1, 3])).to.deep.equal({ a: 1, b: 3 });
+      });
+
+      it('correctly overrides defaults when the value given does not meet the restrictions', function () {
+        expect(ArgParser.align(['a', { b: { default: 2, restrict: 2 } }], [1, 3])).to.be.false();
+      });
+
+      it('throws an error if the restrict type is not one of string, number, or array', function () {
+        expect(ArgParser.align.bind(['a', { b: { restrict: {} } }], [1, 2])).to.throw(TypeError);
+      });
+    });
   });
 
   describe('validate', function () {

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -12,7 +12,7 @@ describe('integration', function () {
     var assertHelp = function (event, commandContext) {
       var descriptions = [
         'testA (tA, A): Test command A',
-        'testB arg1 arg2 arg3:3: Test command B',
+        'testB arg1 arg2 [arg3:3]: Test command B',
         'testC arg1 arg2...: Test command C',
         'help: display this help message'
       ];


### PR DESCRIPTION
This adds a new type of argument: a configured argument.

A configured argument is an object with one key, whose value is another object. The nested object can specify two parameters: `default` and `restrict`.

The `default` parameter lets you specify a default value for the configured argument.

The `restrict` parameter lets you restrict the values that are passed in. `restrict` can be a string, number, or array. If it is an array, the value will be permitted if it matches any element in the array. If the value does not match the restriction, the help message will be shown.

```javascript
slackbot.addCommand(
  'test-command',
  [{ arg1: { default: 'default value', restrict: ['foo', 'bar'] } }],
  'Test command',
  function (options, callback) {
    callback(null, this.ephemeralResponse(options.args.arg1));
  });
```

```
# Returns 'foo'
/testbot test-command foo

# Returns 'bar'
/testbot test-command bar

# Returns help message
/testbot test-command foobar

# Returns 'default value'
/testbot test-command
```