### PR TITLE
Add body to builtevent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+.idea/*

--- a/index.js
+++ b/index.js
@@ -5,9 +5,10 @@ var qs = require('qs');
 
 // build a response to return to Slack
 var buildResponse = function (response_type, response) {
+
   var modifiedResponse = response;
   if (typeof response === 'string') {
-    return { response_type: response_type, text: response };
+    return { response_type: response_type, text: response }; //Need to be  able to respond with response_url as well
   }
   modifiedResponse.response_type = response_type;
   return modifiedResponse;
@@ -146,15 +147,15 @@ SlackBot.prototype.findCommand = function (payload) {
 // control the flow of queries from Slack
 SlackBot.prototype.buildRouter = function () {
   return function (event, context) {
-    var body = qs.parse(event.body);
     var builtEvent = event;
+    builtEvent.body = qs.parse(builtEvent.body);
     var foundCommand;
 
-    if (this.config.token && (!body.token || body.token !== this.config.token)) {
+    if (this.config.token && (!builtEvent.body.token || builtEvent.body.token !== this.config.token)) {
       return context.fail('Invalid Slack token');
     }
 
-    foundCommand = this.findCommand(body.text);
+    foundCommand = this.findCommand(builtEvent.body.text);
     builtEvent.args = foundCommand.args;
     return this.callCommand(foundCommand.commandName, builtEvent, context.done);
   }.bind(this);

--- a/index.js
+++ b/index.js
@@ -5,10 +5,9 @@ var qs = require('qs');
 
 // build a response to return to Slack
 var buildResponse = function (response_type, response) {
-
   var modifiedResponse = response;
   if (typeof response === 'string') {
-    return { response_type: response_type, text: response }; //Need to be  able to respond with response_url as well
+    return { response_type: response_type, text: response };
   }
   modifiedResponse.response_type = response_type;
   return modifiedResponse;

--- a/index.js
+++ b/index.js
@@ -146,9 +146,9 @@ SlackBot.prototype.findCommand = function (payload) {
 // control the flow of queries from Slack
 SlackBot.prototype.buildRouter = function () {
   return function (event, context) {
+    var foundCommand;
     var builtEvent = event;
     builtEvent.body = qs.parse(builtEvent.body);
-    var foundCommand;
 
     if (this.config.token && (!builtEvent.body.token || builtEvent.body.token !== this.config.token)) {
       return context.fail('Invalid Slack token');


### PR DESCRIPTION
I could do this on the slackbot side but this seems more reusable. I'm looking for this for our gocd slackbot so I can access the `response_url`.

Includes:
```token=gIkuvaNzQIHg97ATvDxqgjtO
team_id=T0001
team_domain=example
channel_id=C2147483705
channel_name=test
user_id=U2147483697
user_name=Steve
command=/weather
text=94070
response_url=https://hooks.slack.com/commands/1234/5678```