### PR TITLE
Add ability to respond to actions from slack buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ The two arguments passed to the command callback are `event` and `callback`. The
 
 The responses for Slack can either be ephemeral (returning to the user that invoked the function) or in-channel (returning to everyone in the channel in which the function was invoked). SlackBot has a built-in helper for each of these types of responses which are `ephemeralResponse` and `inChannelResponse` respectively. If you pass a string to either one of these functions they return a correctly-formatted object. If you want more fine-grained control, you can pass an object to them and they will set the `response_type` attribute. You can also ignore these functions entirely if you want to return a custom payload.
 
+## Responding to Buttons with Actions
+
+See the [slack documentation](https://api.slack.com/docs/message-buttons) for more information on buttons.
+The action configured must match the `name` value of the presented button.
+There's no need to use inChannelResponse or ephemeralResponse since your provided message will replace the existing message when using the callback.
+
+```javascript
+slackbot.addAction('buttonPress', function (event, callback) {
+  callback(null, { text: "You pressed a button" });
+});
+```
+
 ## Security
 
 Slackbots can optionally be locked down with the token provided by slack. If provided, the token will be checked against each request. It is recommended to provide a token whenever possible, as the endpoint is otherwise vulnerable to exploitation. It is usually easiest to maintain the token in an environment variable, like so:

--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@ SlackBot.prototype.buildRouter = function () {
     }
 
     builtEvent.body = qs.parse(builtEvent.body);
-    if(builtEvent.body.payload) {
+    if (builtEvent.body.payload) {
       builtEvent.body = JSON.parse(builtEvent.body.payload);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-slack-router",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "A utility class for managing Slack slashcommands in an AWS lambda function",
   "main": "index.js",
   "scripts": {

--- a/test/actions-test.js
+++ b/test/actions-test.js
@@ -1,0 +1,19 @@
+var chai = require('chai');
+var expect = chai.expect;
+var SlackBot = require('../index');
+
+describe('managing actions', function () {
+  var slackbot;
+  var testAction;
+
+  beforeEach(function () {
+    slackbot = new SlackBot();
+    testAction = function () {};
+  });
+
+  it('adds an action', function () {
+    slackbot.addAction('test', testAction);
+
+    expect(slackbot.test).to.equal(testAction);
+  });
+});

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -36,6 +36,9 @@ describe('integration', function () {
     slackbot.addCommand('testC', ['arg1', 'arg2...'], 'Test command C', function (event, cb) {
       cb(null, this.ephemeralResponse(event.args.arg2.join(' ')));
     });
+    slackbot.addAction('testButtonAction', function (event, cb) {
+      cb(null, { text: 'You pressed the ' + event.body.actions[0].name + ' button' });
+    });
 
     slackbot.aliasCommand('testA', 'tA', 'A');
 
@@ -98,6 +101,16 @@ describe('integration', function () {
         text: 'A response',
         response_type: 'ephemeral'
       });
+    });
+
+    it('routes to the appropriate action', function () {
+      var event = {
+        body: 'payload={\"actions\":[{\"name\":\"testButtonAction\",\"value\":\"testValue\"}],\"token\":\"token\"}'
+      };
+      slackbot.buildRouter()(event, context, callback);
+
+      expect(callback).to.have.been.calledWithExactly(null,
+        { text: 'You pressed the testButtonAction button' });
     });
 
     it('supports splatting the last argument', function () {


### PR DESCRIPTION
https://api.slack.com/docs/message-buttons

Note: This PR assumes you are responding to actions using the callback, not a delayed response using the `response_url` from Slack. If you use delayed responses with lambda, you may see timing issues in which your delayed response arrives first. The 200 OK callback will then replace your intended response message.